### PR TITLE
Cleaning up previous edition's dates and schedule/guide links

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,15 +37,9 @@ golden_dino: show
       >
       <div class="d-none d-sm-none d-md-block">&nbsp;|&nbsp;</div>
       <div>
-        <a href="/schedule/2019.html"> 
-          <time itemprop="startDate" content="2019-05-31"
-            >May 31<sup>st</sup></time
+          <time itemprop="endDate" content="2020"
+            > 2020</time
           >
-          -
-          <time itemprop="endDate" content="2019-06-02"
-            >June 2<sup>nd</sup> 2019</time
-          >
-        </a>
       </div>
 
       <div class="d-none d-sm-none d-md-none d-lg-block">&nbsp;|&nbsp;</div>
@@ -60,24 +54,6 @@ golden_dino: show
         </div>
       </div>
     </h2>
-    <nav>
-      <ul class="nav justify-content-center">
-        <li class="nav-item">
-          <a class="nav-link ft-clr-2" href="/schedule/2019.html">
-            <i class="far fa-calendar-alt ft-clr-1"></i>
-            &nbsp;
-            Schedule
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link ft-clr-2" target="_blank" href="/assets/downloads/2019/2019HFWProgram-02.pdf">
-            <i class="far fa-map ft-clr-1"></i>
-            &nbsp;
-            Festival Guide
-          </a>
-        </li>
-      </ul>
-    </nav>
   </div>
 
   <div class="contrast-container">


### PR DESCRIPTION
How it'd look like

I thought about adding (Dates TBD) after 2020. Or "June" before 2020. But wasn't sure.
Let me know if any of those or something else would be better.

<img width="1430" alt="Screen Shot 2019-08-01 at 1 58 11 PM" src="https://user-images.githubusercontent.com/8120072/62328332-b6062d00-b467-11e9-8acf-bdfa0133bf74.png">
